### PR TITLE
Add support for URL parameters and JSON body (strings only)

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,0 +1,3 @@
+class TestBlankAssertion:
+    def test_blank_assertion(self):
+        assert True

--- a/zum/__init__.py
+++ b/zum/__init__.py
@@ -1,5 +1,5 @@
 """
-Init file for the zum module.
+Init file for the zum library.
 """
 
 version_info = (0, 0, 1)

--- a/zum/abstractions.py
+++ b/zum/abstractions.py
@@ -14,11 +14,16 @@ class Endpoint:
     """
 
     def __init__(
-        self, route: str, method: str, params: Optional[List[str]] = None
+        self,
+        route: str,
+        method: str,
+        params: Optional[List[str]] = None,
+        body: Optional[List[str]] = None,
     ) -> None:
         self.route = route
         self.method = method
         self.params = params
+        self.body = body
 
     def parse_params(self, options: List[Any]) -> Tuple[Dict[str, Any], List[Any]]:
         if self.params is None:
@@ -29,7 +34,19 @@ class Endpoint:
             )
         return (
             {x[0]: x[1] for x in zip(self.params, options)},
-            options[len(self.params):]
+            options[len(self.params) :],
+        )
+
+    def parse_body(self, options: List[Any]) -> Tuple[Dict[str, Any], List[Any]]:
+        if self.body is None:
+            return {}, options
+        if len(options) < len(self.body):
+            raise MissingEndpointParamsError(
+                "Invalid amount of params passed to the command."
+            )
+        return (
+            {x[0]: x[1] for x in zip(self.body, options)},
+            options[len(self.body) :],
         )
 
     def get_route(self, **params: Any) -> str:

--- a/zum/abstractions.py
+++ b/zum/abstractions.py
@@ -1,5 +1,5 @@
 """
-A module for containing the abstractions of zum.
+A module for containing the abstractions of the zum library.
 """
 
 

--- a/zum/abstractions.py
+++ b/zum/abstractions.py
@@ -2,6 +2,10 @@
 A module for containing the abstractions of the zum library.
 """
 
+from typing import Any, Dict, List, Optional, Tuple
+
+from zum.errors import MissingEndpointParamsError
+
 
 class Endpoint:
 
@@ -9,9 +13,27 @@ class Endpoint:
     Class to encapsulate an endpoint.
     """
 
-    def __init__(self, route: str, method: str) -> None:
+    def __init__(
+        self, route: str, method: str, params: Optional[List[str]] = None
+    ) -> None:
         self.route = route
         self.method = method
+        self.params = params
+
+    def parse_params(self, options: List[Any]) -> Tuple[Dict[str, Any], List[Any]]:
+        if self.params is None:
+            return {}, options
+        if len(options) < len(self.params):
+            raise MissingEndpointParamsError(
+                "Invalid amount of params passed to the command."
+            )
+        return (
+            {x[0]: x[1] for x in zip(self.params, options)},
+            options[len(self.params):]
+        )
+
+    def get_route(self, **params: Any) -> str:
+        return self.route.format(**params)
 
 
 class Metadata:

--- a/zum/abstractions.py
+++ b/zum/abstractions.py
@@ -62,11 +62,11 @@ class Endpoint:
         return self.route.format(**params)
 
 
-class Metadata:
+class Metadata:  # pylint: disable=R0903
 
     """
     Class to encapsulate the metadata information.
     """
 
-    def __init__(self, server: str) -> None:  # pylint: disable=R0903
+    def __init__(self, server: str) -> None:
         self.server = server.rstrip("/")

--- a/zum/abstractions.py
+++ b/zum/abstractions.py
@@ -26,6 +26,10 @@ class Endpoint:
         self.body = body
 
     def parse_params(self, options: List[Any]) -> Tuple[Dict[str, Any], List[Any]]:
+        """
+        Parse the options list into a params dictionary and
+        the rest of the options list.
+        """
         if self.params is None:
             return {}, options
         if len(options) < len(self.params):
@@ -38,6 +42,10 @@ class Endpoint:
         )
 
     def parse_body(self, options: List[Any]) -> Tuple[Dict[str, Any], List[Any]]:
+        """
+        Parse the options list into a json body dictionary and
+        the rest of the options list.
+        """
         if self.body is None:
             return {}, options
         if len(options) < len(self.body):
@@ -50,6 +58,7 @@ class Endpoint:
         )
 
     def get_route(self, **params: Any) -> str:
+        """Interpolate params into the route."""
         return self.route.format(**params)
 
 
@@ -59,5 +68,5 @@ class Metadata:
     Class to encapsulate the metadata information.
     """
 
-    def __init__(self, server: str) -> None:
+    def __init__(self, server: str) -> None:  # pylint: disable=R0903
         self.server = server.rstrip("/")

--- a/zum/cli.py
+++ b/zum/cli.py
@@ -2,8 +2,7 @@
 A module to route the zum CLI traffic.
 """
 
-import sys
-from argparse import ArgumentParser, _SubParsersAction
+from argparse import ArgumentParser
 from typing import Any, List
 
 import zum

--- a/zum/cli.py
+++ b/zum/cli.py
@@ -1,5 +1,5 @@
 """
-A module to route the CLI traffic.
+A module to route the zum CLI traffic.
 """
 
 import sys
@@ -7,7 +7,7 @@ from argparse import ArgumentParser, _SubParsersAction
 from typing import Any, List
 
 import zum
-from zum.executor import Executor
+from zum.core import Executor
 
 
 def dispatcher(*args: Any, **kwargs: Any) -> None:

--- a/zum/cli.py
+++ b/zum/cli.py
@@ -21,18 +21,7 @@ def dispatcher(*args: Any, **kwargs: Any) -> None:
     parser = generate_parser(actions_list)
     parsed_args = parser.parse_args(*args, **kwargs)
 
-    try:
-        action = parsed_args.action[0]
-        if action in actions_list:
-            executor.execute(action)
-        else:
-            print(f"Invalid action {action}.")
-            parser.print_help()
-            sys.exit(1)
-    except AttributeError:
-        print("An argument is required for the zum command.")
-        parser.print_help()
-        sys.exit(1)
+    executor.execute(parsed_args.action[0], parsed_args.params)
 
 
 def generate_parser(actions_list: List[str]) -> ArgumentParser:

--- a/zum/constants.py
+++ b/zum/constants.py
@@ -1,1 +1,10 @@
+"""
+A module to hold all the constants for the zum library.
+"""
+
+
+# Config file
 CONFIG_FILE_NAME = "zum.toml"
+
+# Endpoints
+DEFAULT_HTTP_METHOD = "get"

--- a/zum/core.py
+++ b/zum/core.py
@@ -3,7 +3,7 @@ The main module of the zum library.
 """
 
 import json
-from typing import Any
+from typing import Any, List
 
 import httpx
 
@@ -19,7 +19,7 @@ class Executor:
         self.metadata = parse_metadata(configs["metadata"])
         self.endpoints = parse_endpoints(configs["endpoints"])
 
-    def execute(self, instruction: str, **kwargs: Any) -> None:
+    def execute(self, instruction: str, params: List[Any]) -> None:
         url = f"{self.metadata.server}{self.endpoints[instruction].route}"
         method = self.endpoints[instruction].method
         response = self.query(url, method)

--- a/zum/core.py
+++ b/zum/core.py
@@ -1,3 +1,7 @@
+"""
+The main module of the zum library.
+"""
+
 import json
 from typing import Any
 

--- a/zum/core.py
+++ b/zum/core.py
@@ -3,7 +3,7 @@ The main module of the zum library.
 """
 
 import json
-from typing import Any, List
+from typing import Any, Dict, List
 
 import httpx
 
@@ -22,14 +22,14 @@ class Executor:
     def execute(self, instruction: str, options: List[Any]) -> None:
         endpoint = self.endpoints[instruction]
         params, remaining_options = endpoint.parse_params(options)
+        body, remaining_options = endpoint.parse_body(remaining_options)
         url = f"{self.metadata.server}{endpoint.get_route(**params)}"
-        method = endpoint.method
-        response = self.query(url, method)
+        response = self.query(url, endpoint.method, body)
         self.handle_response(response)
 
     @staticmethod
-    def query(url: str, method: str) -> httpx.Response:
-        return httpx.request(method, url)
+    def query(url: str, method: str, body: Dict[str, Any]) -> httpx.Response:
+        return httpx.request(method, url, json=body)
 
     @staticmethod
     def handle_response(response: httpx.Response) -> None:

--- a/zum/core.py
+++ b/zum/core.py
@@ -13,6 +13,11 @@ from zum.validations import validate_configs
 
 
 class Executor:
+
+    """
+    Class to encapsulate the execution flow of a request.
+    """
+
     def __init__(self) -> None:
         configs = read_config_file()
         validate_configs(configs)
@@ -20,6 +25,10 @@ class Executor:
         self.endpoints = parse_endpoints(configs["endpoints"])
 
     def execute(self, instruction: str, options: List[Any]) -> None:
+        """
+        Execute the query corresponding to the instruction using the options to
+        generate the URL params and json body.
+        """
         endpoint = self.endpoints[instruction]
         params, remaining_options = endpoint.parse_params(options)
         body, remaining_options = endpoint.parse_body(remaining_options)
@@ -29,10 +38,12 @@ class Executor:
 
     @staticmethod
     def query(url: str, method: str, body: Dict[str, Any]) -> httpx.Response:
+        """Queries the API."""
         return httpx.request(method, url, json=body)
 
     @staticmethod
     def handle_response(response: httpx.Response) -> None:
+        """Show the response."""
         view = json.dumps(
             response.json(), indent=2, sort_keys=False, ensure_ascii=False
         )

--- a/zum/core.py
+++ b/zum/core.py
@@ -19,9 +19,11 @@ class Executor:
         self.metadata = parse_metadata(configs["metadata"])
         self.endpoints = parse_endpoints(configs["endpoints"])
 
-    def execute(self, instruction: str, params: List[Any]) -> None:
-        url = f"{self.metadata.server}{self.endpoints[instruction].route}"
-        method = self.endpoints[instruction].method
+    def execute(self, instruction: str, options: List[Any]) -> None:
+        endpoint = self.endpoints[instruction]
+        params, remaining_options = endpoint.parse_params(options)
+        url = f"{self.metadata.server}{endpoint.get_route(**params)}"
+        method = endpoint.method
         response = self.query(url, method)
         self.handle_response(response)
 

--- a/zum/errors.py
+++ b/zum/errors.py
@@ -5,3 +5,7 @@ A module to hold the custom exceptions for the zum library.
 
 class InvalidConfigFileError(Exception):
     """An exception for when the config file is invalid or missing."""
+
+
+class MissingEndpointParamsError(Exception):
+    """An exception for when an incorrect amount of params is passed."""

--- a/zum/errors.py
+++ b/zum/errors.py
@@ -1,2 +1,7 @@
+"""
+A module to hold the custom exceptions for the zum library.
+"""
+
+
 class InvalidConfigFileError(Exception):
     """An exception for when the config file is invalid or missing."""

--- a/zum/parser.py
+++ b/zum/parser.py
@@ -23,5 +23,6 @@ def parse_endpoint(data: dict) -> Endpoint:
     return Endpoint(
         route=data["route"],
         method=data.get("method") or DEFAULT_HTTP_METHOD,
-        params=data.get("params")
+        params=data.get("params"),
+        body=data.get("body"),
     )

--- a/zum/parser.py
+++ b/zum/parser.py
@@ -1,10 +1,13 @@
-"""Module for the core parsing logic of zum."""
+"""
+Module for the core parsing logic of zum.
+"""
 
 from typing import Any, Dict
 
 import tomlkit
 
 from zum.abstractions import Endpoint, Metadata
+from zum.constants import DEFAULT_HTTP_METHOD
 from zum.errors import InvalidConfigFileError
 
 
@@ -17,4 +20,5 @@ def parse_endpoints(endpoints: Dict[str, Any]) -> Dict[str, Endpoint]:
 
 
 def parse_endpoint(data: dict) -> Endpoint:
-    return Endpoint(route=data["route"], method=data["method"])
+    http_method = data["method"] if "method" in data else DEFAULT_HTTP_METHOD
+    return Endpoint(route=data["route"], method=http_method)

--- a/zum/parser.py
+++ b/zum/parser.py
@@ -4,22 +4,22 @@ Module for the core parsing logic of zum.
 
 from typing import Any, Dict
 
-import tomlkit
-
 from zum.abstractions import Endpoint, Metadata
 from zum.constants import DEFAULT_HTTP_METHOD
-from zum.errors import InvalidConfigFileError
 
 
 def parse_metadata(metadata: Dict[str, str]) -> Metadata:
+    """Parse the metadata into a Metadata object."""
     return Metadata(server=metadata["server"])
 
 
 def parse_endpoints(endpoints: Dict[str, Any]) -> Dict[str, Endpoint]:
+    """Parse all the endpoints."""
     return {name: parse_endpoint(endpoint) for name, endpoint in endpoints.items()}
 
 
 def parse_endpoint(data: dict) -> Endpoint:
+    """Parse an endpoint's data into an Endpoint object."""
     return Endpoint(
         route=data["route"],
         method=data.get("method") or DEFAULT_HTTP_METHOD,

--- a/zum/parser.py
+++ b/zum/parser.py
@@ -20,5 +20,8 @@ def parse_endpoints(endpoints: Dict[str, Any]) -> Dict[str, Endpoint]:
 
 
 def parse_endpoint(data: dict) -> Endpoint:
-    http_method = data["method"] if "method" in data else DEFAULT_HTTP_METHOD
-    return Endpoint(route=data["route"], method=http_method)
+    return Endpoint(
+        route=data["route"],
+        method=data.get("method") or DEFAULT_HTTP_METHOD,
+        params=data.get("params")
+    )

--- a/zum/utils.py
+++ b/zum/utils.py
@@ -1,3 +1,7 @@
+"""
+A module to hold some utilities for the zum library.
+"""
+
 from typing import Any, Dict
 
 import tomlkit

--- a/zum/utils.py
+++ b/zum/utils.py
@@ -10,6 +10,7 @@ from zum.constants import CONFIG_FILE_NAME
 
 
 def read_config_file() -> Dict[str, Any]:
+    """Read and parse the config file."""
     with open(CONFIG_FILE_NAME, "r") as raw_configs:
         configs = raw_configs.read()
     return tomlkit.parse(configs)

--- a/zum/validations.py
+++ b/zum/validations.py
@@ -1,3 +1,7 @@
+"""
+A module to hold all the validation methods for the zum library.
+"""
+
 from typing import Any, Dict
 
 from zum.errors import InvalidConfigFileError

--- a/zum/validations.py
+++ b/zum/validations.py
@@ -8,6 +8,7 @@ from zum.errors import InvalidConfigFileError
 
 
 def validate_metadata(configs: Dict[str, Any]) -> None:
+    """Validate that the metadata key of the config file is not malformed."""
     if "metadata" not in configs:
         raise InvalidConfigFileError("Missing 'metadata' section of the config file")
     if "server" not in configs["metadata"]:
@@ -17,6 +18,7 @@ def validate_metadata(configs: Dict[str, Any]) -> None:
 
 
 def validate_endpoints(configs: Dict[str, Any]) -> None:
+    """Validate that the endpoints key of the config file is not malformed."""
     if "endpoints" not in configs:
         raise InvalidConfigFileError("Missing 'endpoints' section of the config file")
     if len(configs["endpoints"]) == 0:
@@ -24,5 +26,6 @@ def validate_endpoints(configs: Dict[str, Any]) -> None:
 
 
 def validate_configs(configs: Dict[str, Any]) -> None:
+    """Validate that the config file is not malformed."""
     validate_metadata(configs)
     validate_endpoints(configs)


### PR DESCRIPTION
# Feature: Add support for URL parameters and JSON body (strings only)

## Description

Now, `zum` can interpolate URL params directly and send a body with the request (for now, only strings are sent).

## Requirements

None.

## Additional changes

None.
