### PR TITLE
Implement support for using a JSON file as request body.

### DIFF
--- a/tests/requests/test_core.py
+++ b/tests/requests/test_core.py
@@ -7,17 +7,24 @@ from zum.requests.errors import InvalidRequestBodyFileError
 from zum.requests.models import Request
 
 
+class TestGenerateRequestWithMissingBodyFilePath:
+    def setup_method(self):
+        self.raw_endpoint = {"route": "/example/", "method": "post", "body": "json"}
+        self.arguments = []
+        self.expected_route = "/example/"
+
+    def test_request_generation_missing_file(self):
+        with pytest.raises(InvalidRequestBodyFileError):
+            generate_request(self.raw_endpoint, self.arguments)
+
+
 class TestGenerateRequestWithNonExistantBodyFile:
     def setup_method(self):
         self.json_file_path = Path(".").joinpath(
             "tests", "requests", "non_existant_body_file.json"
         )
-        self.raw_endpoint = {
-            "route": "/example/",
-            "method": "post",
-            "bodyPath": self.json_file_path.absolute(),
-        }
-        self.arguments = []
+        self.raw_endpoint = {"route": "/example/", "method": "post", "body": "json"}
+        self.arguments = [self.json_file_path.absolute()]
         self.expected_route = "/example/"
 
     def test_request_generation_missing_file(self):
@@ -39,7 +46,7 @@ class TestGenerateRequestWithExistingBodyFile:
             "method": "post",
             "params": ["id", "query"],
             "headers": ["Authorization"],
-            "bodyPath": self.json_file_path.absolute(),
+            "body": "json",
         }
         self.params = {"id": 35, "query": "mystring"}
         self.headers = {"Authorization": "Bearer F"}
@@ -48,6 +55,7 @@ class TestGenerateRequestWithExistingBodyFile:
             self.params["id"],
             self.params["query"],
             self.headers["Authorization"],
+            self.json_file_path.absolute(),
         ]
         self.expected_route = (
             f"/example/{self.params['id']}?query={self.params['query']}"

--- a/tests/requests/test_core.py
+++ b/tests/requests/test_core.py
@@ -1,10 +1,75 @@
+from pathlib import Path
+
 import pytest
 
 from zum.requests.core import generate_request
+from zum.requests.errors import InvalidRequestBodyFileError
 from zum.requests.models import Request
 
 
-class TestGenerateRequest:
+class TestGenerateRequestWithNonExistantBodyFile:
+    def setup_method(self):
+        self.json_file_path = Path(".").joinpath(
+            "tests", "requests", "non_existant_body_file.json"
+        )
+        self.raw_endpoint = {
+            "route": "/example/",
+            "method": "post",
+            "bodyPath": self.json_file_path.absolute(),
+        }
+        self.arguments = []
+        self.expected_route = "/example/"
+
+    def test_request_generation_missing_file(self):
+        with pytest.raises(InvalidRequestBodyFileError):
+            generate_request(self.raw_endpoint, self.arguments)
+
+    def test_request_generation_body_file_is_a_folder(self):
+        self.json_file_path.mkdir()
+        with pytest.raises(InvalidRequestBodyFileError):
+            generate_request(self.raw_endpoint, self.arguments)
+        self.json_file_path.rmdir()
+
+
+class TestGenerateRequestWithExistingBodyFile:
+    def setup_method(self):
+        self.json_file_path = Path(".").joinpath("tests", "requests", "json_body.json")
+        self.raw_endpoint = {
+            "route": "/example/{id}?query={query}",
+            "method": "post",
+            "params": ["id", "query"],
+            "headers": ["Authorization"],
+            "bodyPath": self.json_file_path.absolute(),
+        }
+        self.params = {"id": 35, "query": "mystring"}
+        self.headers = {"Authorization": "Bearer F"}
+        self.body = {"name": "Dani", "city": "Barcelona"}
+        self.arguments = [
+            self.params["id"],
+            self.params["query"],
+            self.headers["Authorization"],
+        ]
+        self.expected_route = (
+            f"/example/{self.params['id']}?query={self.params['query']}"
+        )
+
+        from json import dumps
+
+        with self.json_file_path.open("a") as request_body_file:
+            request_body_file.write(dumps(self.body))
+
+    def test_request_generation(self):
+        request = generate_request(self.raw_endpoint, self.arguments)
+        self.json_file_path.unlink()
+
+        assert isinstance(request, Request)
+        assert request.params == self.params
+        assert request.headers == self.headers
+        assert request.body == self.body
+        assert request.route == self.expected_route
+
+
+class TestGenerateRequestWithoutBodyFile:
     def setup_method(self):
         self.raw_endpoint = {
             "route": "/example/{id}?query={query}",

--- a/zum/requests/core.py
+++ b/zum/requests/core.py
@@ -2,8 +2,11 @@
 Module for the core requests logic of zum.
 """
 
+from json import load
+from pathlib import Path
 from typing import Any, Dict, List
 
+from zum.requests.errors import InvalidRequestBodyFileError
 from zum.requests.helpers import reduce_arguments
 from zum.requests.models import Request
 
@@ -19,5 +22,26 @@ def generate_request(raw_endpoint: Dict[str, Any], arguments: List[str]) -> Requ
     headers, remaining_arguments = reduce_arguments(
         raw_endpoint.get("headers"), remaining_arguments
     )
-    body, _ = reduce_arguments(raw_endpoint.get("body"), remaining_arguments)
+
+    body: Dict[str, Any] = dict()
+    if raw_endpoint.get("bodyPath"):
+        body_file: Path = Path(raw_endpoint.get("bodyPath", ""))
+        if body_file.exists() and body_file.is_file():
+            with body_file.open("r") as body_contents:
+                body = load(body_contents)
+        else:
+            if not body_file.exists():
+                raise InvalidRequestBodyFileError(
+                    f"Request body file located at '{body_file.absolute()}' does not"
+                    + "exist!"
+                )
+
+            if not body_file.is_file():
+                raise InvalidRequestBodyFileError(
+                    f"Request body file located at '{body_file.absolute()}' is not"
+                    + "a file!"
+                )
+    else:
+        body, _ = reduce_arguments(raw_endpoint.get("body"), remaining_arguments)
+
     return Request(raw_endpoint["route"], raw_endpoint["method"], params, headers, body)

--- a/zum/requests/errors.py
+++ b/zum/requests/errors.py
@@ -17,3 +17,10 @@ class InvalidBodyParameterTypeError(Exception):
     An exception for when a body parameter tries to be casted to a
     type that doesn't match its intrinsec type.
     """
+
+
+class InvalidRequestBodyFileError(Exception):
+    """
+    An exception used for any errors related to a JSON file provided as the
+    body of a request.
+    """


### PR DESCRIPTION
# [Feature]: Support for using files as request bodies. May resolve issue  #8 

## Description

This pull request adds support for using the contents of a file as the JSON body of a request. This is currently done by providing a `bodyPath` variable in the `zum.toml` file. If the file path exists and contains a file, the contents of the file are read and parsed as JSON. The contents of the file are then sent with the request.

If the user provides both a `body` and `bodyPath` variable like:
```toml
[endpoints.test-post]
route = "/test-post"
method = "post"
body = ["arg1", "arg2"]
bodyPath = "/some/path/to/request_body_file"
```
the contents of `body` are ignored and the file located at `bodyPath` is used instead.
## Requirements
None.

## Additional changes
Added tests for the new functionality.
