### PR TITLE
Add 'number' as a body value type

### DIFF
--- a/tests/requests/test_helpers.py
+++ b/tests/requests/test_helpers.py
@@ -91,6 +91,14 @@ class TestCastValue:
         output = cast_value(*self.float["input"])
         assert output == self.float["output"]
 
+    def test_number(self):
+        integer_output = cast_value(*self.integer["input"])
+        float_output = cast_value(*self.float["input"])
+        assert (
+            integer_output == self.integer["output"]
+            and float_output == self.float["output"]
+        )
+
     def test_invalid_boolean(self):
         with pytest.raises(InvalidBodyParameterTypeError) as excinfo:
             cast_value(*self.invalid_boolean)

--- a/tests/requests/test_helpers.py
+++ b/tests/requests/test_helpers.py
@@ -92,8 +92,8 @@ class TestCastValue:
         assert output == self.float["output"]
 
     def test_number(self):
-        integer_output = cast_value(*self.integer["input"])
-        float_output = cast_value(*self.float["input"])
+        integer_output = cast_value(self.integer["input"][0], "number")
+        float_output = cast_value(self.float["input"][0], "number")
         assert (
             integer_output == self.integer["output"]
             and float_output == self.float["output"]

--- a/zum/constants.py
+++ b/zum/constants.py
@@ -22,4 +22,4 @@ HTTP_METHODS = [
 ]
 
 # Request body value types
-REQUEST_BODY_VALUE_TYPES = ["string", "integer", "float", "boolean", "null"]
+REQUEST_BODY_VALUE_TYPES = ["string", "integer", "float", "number", "boolean", "null"]

--- a/zum/requests/helpers.py
+++ b/zum/requests/helpers.py
@@ -57,7 +57,7 @@ def cast_value(value: str, casting_type: str) -> Any:
     """Casts value depending on the casting type."""
     if casting_type == "integer":
         return int(value)
-    if casting_type == "float":
+    if casting_type in ["float", "number"]:
         return float(value)
     if casting_type == "boolean":
         if value not in ["true", "false"]:


### PR DESCRIPTION
# Feature: Add 'number' as a body value type

## Description

[JSON](https://www.w3schools.com/js/js_json_datatypes.asp) does not define 'integer' and 'float' as valid data types, but rather merges them both into the 'number' data type. This PR includes 'number' as part of the data types, but does not remove 'integer' and 'float' for backward compatibility.

I think that 'array' and 'object' should also be allowed (somehow).

## Requirements

None.

## Additional changes

None.
